### PR TITLE
Update TestLinkSite.java

### DIFF
--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -167,7 +167,7 @@ public class TestLinkSite {
 				filteredTestcases.add(testCase);
 		}
 		
-		return filteredTestcases.toArray();
+		return ArrayList<TestCase>.toArray(filteredTestcases);
 	}
 	
 	/**

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -37,7 +37,7 @@ import br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCase;
 import br.eti.kinoshita.testlinkjavaapi.model.TestPlan;
 import br.eti.kinoshita.testlinkjavaapi.model.TestProject;
-
+import java.util.ArrayList;
 /**
  * Immutable object that represents the TestLink site with a Test Project, 
  * a Test Plan and a Build.

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -163,7 +163,7 @@ public class TestLinkSite {
 				}
 			}
 			
-			if(platform != null && testCase.getPlatform().equals(platform))
+			if(platform == null || testCase.getPlatform().equals(platform))
 				filteredTestcases.add(testCase);
 		}
 		

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -143,7 +143,9 @@ public class TestLinkSite {
 				ExecutionType.AUTOMATED, 
 				Boolean.TRUE,
 				TestCaseDetails.FULL);			
-
+		
+		ArrayList<TestCase> filteredTestcases = new ArrayList<TestCase>();
+		
 		for( final TestCase testCase : testCases ) {
 			testCase.setTestProjectId(getTestProject().getId());
 			testCase.setExecutionStatus(ExecutionStatus.NOT_RUN);
@@ -159,9 +161,12 @@ public class TestLinkSite {
 					testCase.getCustomFields().add(customField);
 				}
 			}
+			
+			if(platform != null && testcase.getPlatform().equals(platform))
+				filteredTestcases.add(testcase);
 		}
 		
-		return testCases;
+		return filteredTestcases.toArray();
 	}
 	
 	/**

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -38,6 +38,7 @@ import br.eti.kinoshita.testlinkjavaapi.model.TestCase;
 import br.eti.kinoshita.testlinkjavaapi.model.TestPlan;
 import br.eti.kinoshita.testlinkjavaapi.model.TestProject;
 import java.util.ArrayList;
+
 /**
  * Immutable object that represents the TestLink site with a Test Project, 
  * a Test Plan and a Build.
@@ -162,8 +163,8 @@ public class TestLinkSite {
 				}
 			}
 			
-			if(platform != null && testcase.getPlatform().equals(platform))
-				filteredTestcases.add(testcase);
+			if(platform != null && testCase.getPlatform().equals(platform))
+				filteredTestcases.add(testCase);
 		}
 		
 		return filteredTestcases.toArray();

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -163,7 +163,7 @@ public class TestLinkSite {
 				}
 			}
 			
-			if(platform == null || testCase.getPlatform().equals(platform))
+			if(platform == null || testCase.getPlatform().getName().equals(platform.getName()))
 				filteredTestcases.add(testCase);
 		}
 		

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -167,7 +167,7 @@ public class TestLinkSite {
 				filteredTestcases.add(testCase);
 		}
 		
-		return ArrayList<TestCase>.toArray(filteredTestcases);
+		return filteredTestcases.toArray(new TestCase[filteredTestcases.size()]);
 	}
 	
 	/**


### PR DESCRIPTION
... to Filter testcases by platform before running it! It seems to be useless to run a test with the wrong platform when the result is never returned to testlink.