### PR TITLE
Added build number and error message in notes of JUnit Test Result

### DIFF
--- a/src/main/java/hudson/plugins/testlink/result/JUnitCaseClassNameResultSeeker.java
+++ b/src/main/java/hudson/plugins/testlink/result/JUnitCaseClassNameResultSeeker.java
@@ -111,10 +111,9 @@ public class JUnitCaseClassNameResultSeeker extends AbstractJUnitResultSeeker {
 								automatedTestCase.addCustomFieldAndStatus(value, status);
 								
 								if(this.isIncludeNotes()) {
-									final String notes = this.getJUnitNotes(caseResult);
+									final String notes = this.getJUnitNotes(caseResult, build.number);
 									automatedTestCase.appendNotes(notes);
 								}
-								
 								classNameTestCase.put(Integer.valueOf(automatedTestCase.getId())+"#"+Arrays.toString(commaSeparatedValues), automatedTestCase);
 							}
 						}
@@ -205,7 +204,7 @@ public class JUnitCaseClassNameResultSeeker extends AbstractJUnitResultSeeker {
 	 * @param testCase JUnit test.
 	 * @return Notes about the JUnit test.
 	 */
-	private String getJUnitNotes( CaseResult testCase )
+	private String getJUnitNotes( CaseResult testCase , int buildNumber)
 	{
 		StringBuilder notes = new StringBuilder();
 		notes.append( 
@@ -213,7 +212,11 @@ public class JUnitCaseClassNameResultSeeker extends AbstractJUnitResultSeeker {
 						testCase.getClassName(), 
 						(testCase.getSuiteResult() != null ? testCase.getSuiteResult().getTimestamp() : null))
 		);
-		
+		/* Added for appending build number and error message */
+		notes.append("\nBuild no : " + buildNumber );
+		if(null != testCase.getErrorDetails() ){
+			notes.append("\nError Message : " + testCase.getErrorDetails());
+		}
 		return notes.toString();
 	}
 

--- a/src/main/java/hudson/plugins/testlink/result/JUnitCaseNameResultSeeker.java
+++ b/src/main/java/hudson/plugins/testlink/result/JUnitCaseNameResultSeeker.java
@@ -97,10 +97,9 @@ public class JUnitCaseNameResultSeeker extends AbstractJUnitResultSeeker {
 								automatedTestCase.addCustomFieldAndStatus(value, status);
 								
 								if(this.isIncludeNotes()) {
-									final String notes = this.getJUnitNotes(caseResult);
+									final String notes = this.getJUnitNotes(caseResult, build.number);
 									automatedTestCase.appendNotes(notes);
 								}
-								
 								super.handleResult(automatedTestCase, build, listener, testlink, suiteResult);
 							}
 						}
@@ -134,7 +133,7 @@ public class JUnitCaseNameResultSeeker extends AbstractJUnitResultSeeker {
 	 * @param testCase JUnit test.
 	 * @return Notes about the JUnit test.
 	 */
-	private String getJUnitNotes( CaseResult testCase )
+	private String getJUnitNotes( CaseResult testCase , int buildNumber)
 	{
 		StringBuilder notes = new StringBuilder();
 		notes.append( 
@@ -145,6 +144,12 @@ public class JUnitCaseNameResultSeeker extends AbstractJUnitResultSeeker {
 						testCase.getFailCount(), 
 						(testCase.getSuiteResult() != null ? testCase.getSuiteResult().getTimestamp() : null))
 		);
+		
+		/* Added for appending build number and error message */
+		notes.append("\nBuild no : " + buildNumber );
+		if(null != testCase.getErrorDetails() ){
+			notes.append("\nError Message : " + testCase.getErrorDetails());
+		}
 		
 		return notes.toString();
 	}

--- a/src/main/java/hudson/plugins/testlink/result/JUnitMethodNameResultSeeker.java
+++ b/src/main/java/hudson/plugins/testlink/result/JUnitMethodNameResultSeeker.java
@@ -99,10 +99,9 @@ public class JUnitMethodNameResultSeeker extends AbstractJUnitResultSeeker {
 								automatedTestCase.addCustomFieldAndStatus(value, status);
 								
 								if(this.isIncludeNotes()) {
-									final String notes = this.getJUnitNotes(caseResult);
+									final String notes = this.getJUnitNotes(caseResult, build.number);
 									automatedTestCase.appendNotes(notes);
 								}
-								
 								super.handleResult(automatedTestCase, build, listener, testlink, suiteResult);
 							}
 						}
@@ -136,7 +135,7 @@ public class JUnitMethodNameResultSeeker extends AbstractJUnitResultSeeker {
 	 * @param testCase JUnit test.
 	 * @return Notes about the JUnit test.
 	 */
-	private String getJUnitNotes( CaseResult testCase )
+	private String getJUnitNotes( CaseResult testCase , int buildNumber)
 	{
 		StringBuilder notes = new StringBuilder();
 		notes.append( 
@@ -148,6 +147,11 @@ public class JUnitMethodNameResultSeeker extends AbstractJUnitResultSeeker {
 						(testCase.getSuiteResult() != null ? testCase.getSuiteResult().getTimestamp() : null))
 		);
 		
+		/* Added for appending build number and error message */
+		notes.append("\nBuild no : " + buildNumber );
+		if(null != testCase.getErrorDetails() ){
+			notes.append("\nError Message : " + testCase.getErrorDetails());
+		}
 		return notes.toString();
 	}
 


### PR DESCRIPTION
Added the build number generated by Jenkins job execution in the notes of TestLink JUnit test result.
Also added the error messages for the failed testcases in the notes of TestLink JUnit Test Result.