### PR TITLE
Enhancement for updating build custom fields values

### DIFF
--- a/src/main/java/hudson/plugins/testlink/AbstractTestLinkBuilder.java
+++ b/src/main/java/hudson/plugins/testlink/AbstractTestLinkBuilder.java
@@ -59,6 +59,10 @@ public class AbstractTestLinkBuilder extends Builder {
      */
     protected String buildName;
     /**
+     * The Build custom fields.
+     */
+    protected String buildCustomFields;
+    /**
      * The platform name.
      */
     protected final String platformName;
@@ -133,7 +137,7 @@ public class AbstractTestLinkBuilder extends Builder {
      * Create a AbstractTestLinkBuilder.
      */
     public AbstractTestLinkBuilder(String testLinkName, String testProjectName, String testPlanName, 
-            String platformName, String buildName, String customFields, String testPlanCustomFields, List<BuildStep> singleBuildSteps,
+            String platformName, String buildName, String buildCustomFields, String customFields, String testPlanCustomFields, List<BuildStep> singleBuildSteps,
             List<BuildStep> beforeIteratingAllTestCasesBuildSteps, List<BuildStep> iterativeBuildSteps,
             List<BuildStep> afterIteratingAllTestCasesBuildSteps, Boolean transactional,
             Boolean failedTestsMarkBuildAsFailure, Boolean failIfNoResults, Boolean failOnNotRun,
@@ -144,6 +148,7 @@ public class AbstractTestLinkBuilder extends Builder {
         this.testPlanName = testPlanName;
         this.platformName = platformName;
         this.buildName = buildName;
+        this.buildCustomFields = buildCustomFields;
         this.customFields = customFields;
         this.testPlanCustomFields = testPlanCustomFields;
         this.singleBuildSteps = singleBuildSteps;
@@ -162,12 +167,12 @@ public class AbstractTestLinkBuilder extends Builder {
      * @deprecated to add test plan custom fields
      */
     public AbstractTestLinkBuilder(String testLinkName, String testProjectName, String testPlanName, 
-            String platformName, String buildName, String customFields, List<BuildStep> singleBuildSteps,
+            String platformName, String buildName, String buildCustomFields, String customFields, List<BuildStep> singleBuildSteps,
             List<BuildStep> beforeIteratingAllTestCasesBuildSteps, List<BuildStep> iterativeBuildSteps,
             List<BuildStep> afterIteratingAllTestCasesBuildSteps, Boolean transactional,
             Boolean failedTestsMarkBuildAsFailure, Boolean failIfNoResults, Boolean failOnNotRun,
             List<ResultSeeker> resultSeekers) {
-        this(testLinkName, testProjectName, testPlanName, platformName, buildName, customFields,
+        this(testLinkName, testProjectName, testPlanName, platformName, buildName, buildCustomFields, customFields,
                 /*testPlanCustomFields*/ null, singleBuildSteps, beforeIteratingAllTestCasesBuildSteps,
                 iterativeBuildSteps, afterIteratingAllTestCasesBuildSteps, transactional, failedTestsMarkBuildAsFailure,
                 failIfNoResults, failOnNotRun, resultSeekers);
@@ -181,8 +186,8 @@ public class AbstractTestLinkBuilder extends Builder {
      * @param testPlanName TestLink Test Plan name.
      * @param platformName TestLink Platform name.
      * @param buildName TestLink Build name.
+     * @param buildCustomFields TestLink Build custom fields.
      * @param customFields TestLink comma-separated list of Custom Fields.
-     * @param keyCustomField Key custom field.
      * @param singleBuildSteps List of build steps to execute once for all automated test cases.
      * @param beforeIteratingAllTestCasesBuildSteps Command executed before iterating all test cases.
      * @param iterativeBuildSteps List of build steps to execute for each Automated Test Case.
@@ -194,13 +199,13 @@ public class AbstractTestLinkBuilder extends Builder {
      * @deprecated
      */
     public AbstractTestLinkBuilder(String testLinkName, String testProjectName, String testPlanName,
-            String platformName, String buildName, String customFields, Boolean executionStatusNotRun,
+            String platformName, String buildName, String buildCustomFields, String customFields, Boolean executionStatusNotRun,
             Boolean executionStatusPassed, Boolean executionStatusFailed, Boolean executionStatusBlocked,
             List<BuildStep> singleBuildSteps, List<BuildStep> beforeIteratingAllTestCasesBuildSteps,
             List<BuildStep> iterativeBuildSteps, List<BuildStep> afterIteratingAllTestCasesBuildSteps,
             Boolean transactional, Boolean failedTestsMarkBuildAsFailure, Boolean failIfNoResults,
             Boolean failOnNotRun, List<ResultSeeker> resultSeekers) {
-        this(testLinkName, testProjectName, testPlanName, platformName, buildName, customFields,
+        this(testLinkName, testProjectName, testPlanName, platformName, buildName, buildCustomFields, customFields,
              /*testPlanCustomFields*/ null, singleBuildSteps, beforeIteratingAllTestCasesBuildSteps,
              iterativeBuildSteps, afterIteratingAllTestCasesBuildSteps, transactional, failedTestsMarkBuildAsFailure,
              failIfNoResults, failOnNotRun, resultSeekers);
@@ -225,6 +230,8 @@ public class AbstractTestLinkBuilder extends Builder {
     public String getBuildName() {
         return this.buildName;
     }
+
+    public String getBuildCustomFields() { return this.buildCustomFields; }
 
     public String getCustomFields() {
         return this.customFields;

--- a/src/main/java/hudson/plugins/testlink/TestLinkBuilder.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkBuilder.java
@@ -28,6 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -90,7 +91,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
             List<BuildStep> afterIteratingAllTestCasesBuildSteps,
             Boolean transactional, Boolean failedTestsMarkBuildAsFailure,
             Boolean failIfNoResults, List<ResultSeeker> resultSeekers) {
-        this(testLinkName, testProjectName, testPlanName, buildName,
+        this(testLinkName, testProjectName, testPlanName, buildName, null,
                 null, customFields, executionStatusNotRun, executionStatusPassed,
                 executionStatusFailed, executionStatusBlocked, singleBuildSteps,
                 beforeIteratingAllTestCasesBuildSteps, iterativeBuildSteps,
@@ -112,7 +113,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
             List<BuildStep> afterIteratingAllTestCasesBuildSteps,
             Boolean transactional, Boolean failedTestsMarkBuildAsFailure,
             Boolean failIfNoResults, Boolean failOnNotRun, List<ResultSeeker> resultSeekers) {
-        super(testLinkName, testProjectName, testPlanName, buildName, null, 
+        super(testLinkName, testProjectName, testPlanName, buildName, null, null,
                 customFields, executionStatusNotRun, executionStatusPassed,
                 executionStatusFailed, executionStatusBlocked, singleBuildSteps,
                 beforeIteratingAllTestCasesBuildSteps, iterativeBuildSteps,
@@ -125,7 +126,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
      * @deprecated to add test plan custom fields
      */
     public TestLinkBuilder(String testLinkName, String testProjectName,
-            String testPlanName, String platformName, String buildName, String customFields,
+            String testPlanName, String platformName, String buildName, String buildCustomFields, String customFields,
             Boolean executionStatusNotRun, Boolean executionStatusPassed,
             Boolean executionStatusFailed, Boolean executionStatusBlocked,
             List<BuildStep> singleBuildSteps,
@@ -134,7 +135,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
             List<BuildStep> afterIteratingAllTestCasesBuildSteps,
             Boolean transactional, Boolean failedTestsMarkBuildAsFailure,
             Boolean failIfNoResults, Boolean failOnNotRun, List<ResultSeeker> resultSeekers) {
-        super(testLinkName, testProjectName, testPlanName, platformName, buildName,
+        super(testLinkName, testProjectName, testPlanName, platformName, buildName, buildCustomFields,
                 customFields, singleBuildSteps, beforeIteratingAllTestCasesBuildSteps, iterativeBuildSteps,
                 afterIteratingAllTestCasesBuildSteps, transactional, failedTestsMarkBuildAsFailure, 
                 failIfNoResults, failOnNotRun, resultSeekers);
@@ -142,7 +143,8 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 
 	@DataBoundConstructor
 	public TestLinkBuilder(String testLinkName, String testProjectName,
-			String testPlanName, String platformName, String buildName, String customFields, String testPlanCustomFields,
+			String testPlanName, String platformName, String buildName,
+			String buildCustomFields, String customFields, String testPlanCustomFields,
 			Boolean executionStatusNotRun, Boolean executionStatusPassed,
 			Boolean executionStatusFailed, Boolean executionStatusBlocked,
 			List<BuildStep> singleBuildSteps,
@@ -151,7 +153,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 			List<BuildStep> afterIteratingAllTestCasesBuildSteps,
 			Boolean transactional, Boolean failedTestsMarkBuildAsFailure,
 			Boolean failIfNoResults, Boolean failOnNotRun, List<ResultSeeker> resultSeekers) {
-		super(testLinkName, testProjectName, testPlanName, platformName, buildName,
+		super(testLinkName, testProjectName, testPlanName, platformName, buildName, buildCustomFields,
 				customFields, testPlanCustomFields, singleBuildSteps, beforeIteratingAllTestCasesBuildSteps, iterativeBuildSteps,
 				afterIteratingAllTestCasesBuildSteps, transactional, failedTestsMarkBuildAsFailure, 
 				failIfNoResults, failOnNotRun, resultSeekers);
@@ -194,6 +196,8 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 					build.getEnvironment(listener), getPlatformName());
 			final String buildName = TestLinkHelper.expandVariable(build.getBuildVariableResolver(),
 					build.getEnvironment(listener), getBuildName());
+			final String buildCustomFields = TestLinkHelper.expandVariable(build.getBuildVariableResolver(),
+					build.getEnvironment(listener), getBuildCustomFields());
 			final String buildNotes = Messages.TestLinkBuilder_Build_Notes();
 			if(LOGGER.isLoggable(Level.FINE)) {
 				LOGGER.log(Level.FINE, "TestLink project name: ["+testProjectName+"]");
@@ -201,9 +205,10 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 				LOGGER.log(Level.FINE, "TestLink platform name: ["+platformName+"]");
 				LOGGER.log(Level.FINE, "TestLink build name: ["+buildName+"]");
 				LOGGER.log(Level.FINE, "TestLink build notes: ["+buildNotes+"]");
+				LOGGER.log(Level.FINE, "TestLink build Custom Fields: ["+buildCustomFields+"]");
 			}
 			// TestLink Site object
-			testLinkSite = this.getTestLinkSite(testLinkUrl, testLinkDevKey, testProjectName, testPlanName, platformName, buildName, buildNotes);
+			testLinkSite = this.getTestLinkSite(testLinkUrl, testLinkDevKey, testProjectName, testPlanName, platformName, buildName, buildCustomFields, buildNotes);
 			
 			if (StringUtils.isNotBlank(platformName) && testLinkSite.getPlatform() == null) 
 			    listener.getLogger().println(Messages.TestLinkBuilder_PlatformNotFound(platformName));
@@ -325,7 +330,7 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 	 */
 	public TestLinkSite getTestLinkSite(String testLinkUrl, String testLinkDevKey, 
 	        String testProjectName, String testPlanName, String platformName, 
-	        String buildName, String buildNotes) throws MalformedURLException {
+	        String buildName, String buildCustomFields, String buildNotes) throws MalformedURLException {
 		final TestLinkAPI api;
 		final URL url = new URL(testLinkUrl);
 		api = new TestLinkAPI(url, testLinkDevKey);
@@ -344,7 +349,17 @@ public class TestLinkBuilder extends AbstractTestLinkBuilder {
 			}
 		}
 
+		/* Extract custom fields and values */
+		java.util.Map<String, String> cfs = new HashMap<String, String>();
+		for (String part: buildCustomFields.split(",")) {
+			String[] cf = part.split(":");
+			String name = cf[0].replaceAll("\\s+", "");
+			String value = cf[1].replaceAll("\\s+", "");
+			cfs.put(name, value);
+		}
+
 		final Build build = api.createBuild(testPlan.getId(), buildName, buildNotes);
+		api.updateBuildCustomFields(build.getId(), testProject.getId(), testPlan.getId(), cfs);
 		return new TestLinkSite(api, testProject, testPlan, platform, build);
 	}
 

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config.jelly
@@ -24,7 +24,11 @@
   <f:entry title="${%Build Name}" help="${rootURL}/../plugin/testlink/help-buildName.html">
 	  <f:textbox name="TestLinkBuilder.buildName" value="${instance.buildName}" />
   </f:entry>
-  
+
+  <f:entry title="${%Build Custom Fields Values}" help="${rootURL}/../plugin/testlink/help-buildCustomFields.html">
+    <f:textbox name="TestLinkBuilder.buildCustomFields" value="${instance.buildCustomFields}" />
+  </f:entry>
+
   <f:entry title="${%Custom Fields}" help="${rootURL}/../plugin/testlink/help-customFields.html">
 	  <f:textbox id="customFields" name="TestLinkBuilder.customFields" value="${instance.customFields}" />
   </f:entry>

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config.properties
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config.properties
@@ -3,6 +3,7 @@ Test\ Project\ Name=Test Project Name
 Test\ Plan\ Name=Test Plan Name
 Platform\ Name=Platform Name
 Build\ Name=Build Name
+Build\ Custom\ Fields\ Values=Build Custom Fields Values
 Custom\ Fields=Custom Fields
 Test\ Plan\ Custom\ Fields=Test Plan Custom Fields
 Key\ Custom\ Field=Key Custom Field

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config_es.properties
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config_es.properties
@@ -3,6 +3,7 @@ Test\ Project\ Name=Nombre del Proyecto de Pruebas
 Test\ Plan\ Name=Nombre del Plan de Pruebas
 Platform\ Name=Nombre de la Plataforma
 Build\ Name=Nombre del Build
+Build\ Custom\ Fields\ Values=Construir valores de campos personalizados
 Custom\ Fields=Campos personalizados
 Key\ Custom\ Field=Campo customizado chave para testes automatizados do TestLink
 Execution\ Status=Execution Status

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config_pt.properties
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/config_pt.properties
@@ -3,6 +3,7 @@ Test\ Project\ Name=Nome do Projeto de Testes
 Test\ Plan\ Name=Nome do Plano de Testes
 Platform\ Name=Nome da Plataforma
 Build\ Name=Nome do Build
+Build\ Custom\ Fields\ Values=Construir valores personalizados Campos
 Custom\ Fields=Campos customizados
 Key\ Custom\ Field=Campo customizado chave para testes automatizados do TestLink
 Single\ Test\ Build\ Steps=Build Steps únicos

--- a/src/main/webapp/help-buildCustomFields.html
+++ b/src/main/webapp/help-buildCustomFields.html
@@ -1,0 +1,11 @@
+<div>
+  <p>
+    Give a list of custom fields values for build.
+  </p>
+  <p>
+    Example: compiler:gcc, build_os:Windows
+  </p>
+  <p>You can use environment variables in this field. For example: 
+  build_$BUILD_ID will be converted to something like 
+  build_YYYY-MM-DD_HH-MI-SS.</p>
+</div>

--- a/src/test/java/hudson/plugins/testlink/TestTestLinkBuilder.java
+++ b/src/test/java/hudson/plugins/testlink/TestTestLinkBuilder.java
@@ -60,7 +60,7 @@ public class TestTestLinkBuilder {
 
     @Before
     public void setUp() throws Exception {
-        builder = new TestLinkBuilder("No testlink", "No project", "No plan", "No platform", "No build",
+        builder = new TestLinkBuilder("No testlink", "No project", "No plan", "No platform", "No build", "Not build custom field",
                 "class, time, sample-job-$BUILD_ID", "host, user",Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, null,
                 null, null, null, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, null);
     }
@@ -89,7 +89,7 @@ public class TestTestLinkBuilder {
     @Test
     public void testNull() {
         builder = new TestLinkBuilder(null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
 
         assertNotNull(builder);
 
@@ -102,6 +102,8 @@ public class TestTestLinkBuilder {
         assertNull(builder.getPlatformName());
 
         assertNull(builder.getBuildName());
+
+        assertNull(builder.getBuildCustomFields());
 
         assertNull(builder.getSingleBuildSteps());
 
@@ -133,7 +135,7 @@ public class TestTestLinkBuilder {
         List<BuildStep> singleBuildSteps = new ArrayList<BuildStep>();
         singleBuildSteps.add(shell);
 
-        builder = new TestLinkBuilder("No testlink", "No project", "No plan", "No platform", "No build", "class, time",
+        builder = new TestLinkBuilder("No testlink", "No project", "No plan", "No platform", "No build", "No build custom fields", "class, time",
                 "host, user", Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, singleBuildSteps, null,
                 null, null, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, null);
 
@@ -156,6 +158,9 @@ public class TestTestLinkBuilder {
 
         assertNotNull(builder.getBuildName());
         assertEquals(builder.getBuildName(), "No build");
+
+        assertNotNull(builder.getBuildCustomFields());
+        assertEquals(builder.getBuildCustomFields(), "No build custom fields");
 
         assertNotNull(builder.getSingleBuildSteps());
         assertEquals(builder.getSingleBuildSteps(), singleBuildSteps);


### PR DESCRIPTION
testlink-plugin does not have option to update custom fields related to build. Like compiler, build config (release, debug etc.) etc.
This PR implements a new input field for jobs to input build custom fields and back end code to update  #testlink.

It depends on TestLink Java API. That also needed enhancement. Corresponding Java API enhancement #https://github.com/kinow/testlink-java-api/pull/71