### PR TITLE
Feature to parse custom fields from Junit.xml and update in TestLink

### DIFF
--- a/src/main/java/hudson/plugins/testlink/TestLinkJunitWrapper.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkJunitWrapper.java
@@ -1,0 +1,155 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) <2011> <Bruno P. Kinoshita>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.testlink;
+
+import hudson.tasks.junit.JUnitParser;
+import hudson.tasks.junit.TestResult;
+import hudson.model.Run;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.DirectoryScanner;
+import hudson.Util;
+import jenkins.MasterToSlaveFileCallable;
+import hudson.remoting.VirtualChannel;
+import org.dom4j.io.SAXReader;
+import hudson.util.io.ParserConfigurator;
+import org.dom4j.Document;
+import org.dom4j.Element;
+import java.util.List;
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by azikha01 on 29/07/2016.
+ */
+public class TestLinkJunitWrapper extends JUnitParser {
+    private Map<String, Map<String, String>> customFields = null;
+    private PrintStream logger = null;
+    private static final Logger LOGGER = Logger.getLogger("hudson.plugins.testlink");
+
+    public TestLinkJunitWrapper(boolean keepLongStdio, boolean allowEmptyResults) {
+        super(keepLongStdio, allowEmptyResults);
+    }
+
+    public TestResult parseResult(String testResultLocations, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
+
+        logger = listener.getLogger();
+        TestResult r = super.parseResult(testResultLocations, build, workspace, launcher, listener);
+
+        /* Second parse of files to find Test Case custom field values */
+        this.customFields = (Map<String, Map<String, String>>)workspace.act(new TestLinkJunitWrapper.ParseResultCallable(testResultLocations, logger));
+        Iterator it = customFields.entrySet().iterator();
+        while (it.hasNext()){
+            Map.Entry pair = (Map.Entry)it.next();
+            logger.println("Test Case " + pair.getKey());
+            Map<String, String> cfs = (Map<String, String>)pair.getValue();
+            Iterator itt = cfs.entrySet().iterator();
+            while (itt.hasNext()) {
+                Map.Entry pairr = (Map.Entry)itt.next();
+                logger.println("\tCustom field = " + pairr.getKey() + " value = " + pairr.getValue());
+            }
+        }
+        return r;
+    }
+
+    private static final class ParseResultCallable extends MasterToSlaveFileCallable<Map<String, Map<String, String>>> {
+        private final String testResults;
+        private final PrintStream logger;
+
+        private ParseResultCallable(String testResults, PrintStream logger) {
+            this.testResults = testResults;
+            this.logger = logger;
+        }
+
+        public Map<String, Map<String, String>> invoke(File ws, VirtualChannel channel) throws IOException {
+            FileSet fs = Util.createFileSet(ws, this.testResults);
+            DirectoryScanner ds = fs.getDirectoryScanner();
+            Map<String, Map<String, String>> customFields = new HashMap<String, Map<String, String>>();
+            String[] files = ds.getIncludedFiles();
+            if(files.length > 0) {
+                String[] reportFiles = ds.getIncludedFiles();
+                File baseDir = ds.getBasedir();
+
+                int len$ = reportFiles.length;
+
+                for(int f = 0; f < len$; ++f) {
+                    String value = reportFiles[f];
+                    File reportFile = new File(baseDir, value);
+
+                    try {
+                        this.parseCustomFields(reportFile, customFields);
+                    } catch (org.dom4j.DocumentException e) {
+                        throw new IOException(e);
+                    }
+                }
+
+            }
+
+            return customFields;
+        }
+
+        private void parseCustomFields (File reportFile, Map<String, Map<String, String>> customFields) throws org.dom4j.DocumentException {
+            String xmlReport = reportFile.getName();
+            SAXReader saxReader = new SAXReader();
+            Document result = saxReader.read(reportFile);
+            Element root = result.getRootElement();
+            List testCases = root.elements("testcase");
+
+            for(Iterator stdout = testCases.iterator(); stdout.hasNext();) {
+                Element tc = (Element)stdout.next();
+                String m = tc.attributeValue("classname");
+                Map<String, String> cfs = new HashMap<String, String>();
+                // Get other attributes and extract custom fields
+                List children = tc.elements();
+                for (Iterator child = children.iterator(); child.hasNext();){
+                    // get tag and text
+                    Element childe = (Element)child.next();
+                    // exclude Junit defined names like error, failure, stdin, stdout
+                    if (childe.getName().equals("skipped") ||
+                            childe.getName().equals("error") ||
+                            childe.getName().equals("failure") ||
+                            childe.getName().equals("system-out") ||
+                            childe.getName().equals("system-err")
+                            ) {
+                        continue;
+                    }
+                    cfs.put(childe.getName(), childe.getText());
+                    // what should we do with these custom fields
+                    customFields.put(m, cfs);
+                }
+            }
+        }
+    }
+
+    public Map<String, Map<String, String>> getCustomFields (){ return customFields;}
+}

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -217,7 +217,7 @@ public class TestLinkSite {
 				null, // bug id
 				platformId, // platform id
 				platformName, // platform name
-				null, // custom fields
+				testCase.getCustomFieldsExecutionValues(), // custom fields
 				null);
 			
 			switch(testCase.getExecutionStatus()) {

--- a/src/main/java/hudson/plugins/testlink/result/TestCaseWrapper.java
+++ b/src/main/java/hudson/plugins/testlink/result/TestCaseWrapper.java
@@ -74,6 +74,11 @@ public class TestCaseWrapper implements Serializable {
 	 */
 	private TestCase testCase;
 
+	/**
+	 * Custom Field execution values
+     */
+	private Map<String, String> customFieldsExecutionValues = null;
+
 	public TestCaseWrapper() {
 		this(new TestCase());
 	}
@@ -147,7 +152,7 @@ public class TestCaseWrapper implements Serializable {
 	/**
 	 * Calculates the new value of this wrapped test case execution status, 
 	 * given a number of custom fields.
-	 * @param numberOfCustomFields
+	 * @param keyCustomFieldName
 	 * @return new value of this wrapped test case execution status
 	 */
 	public ExecutionStatus getExecutionStatus(String keyCustomFieldName) {
@@ -308,4 +313,7 @@ public class TestCaseWrapper implements Serializable {
 		this.testCase.setFullExternalId(fullExternalId);
 	}
 
+	public void setCustomFieldExecutionValue(Map<String, String> cfs) {this.customFieldsExecutionValues = cfs;}
+
+	public Map<String, String> getCustomFieldsExecutionValues(){return this.customFieldsExecutionValues;}
 }

--- a/src/test/java/hudson/plugins/testlink/TestTestLinkSite.java
+++ b/src/test/java/hudson/plugins/testlink/TestTestLinkSite.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import hudson.plugins.testlink.result.TestCaseWrapper;
 
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -32,6 +33,8 @@ import br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCase;
 import br.eti.kinoshita.testlinkjavaapi.model.TestPlan;
 import br.eti.kinoshita.testlinkjavaapi.model.TestProject;
+
+import java.util.HashMap;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestTestLinkSite {
@@ -86,7 +89,7 @@ public class TestTestLinkSite {
 		verify(api)
 				.reportTCResult(3, 4, 2, status, 1,
 						"build-name", "notes", null, null, null, "platform",
-						null, null);
+						new HashMap<String, String>(), null);
 		Report report = testLinkSite.getReport();
 		assertThat(report.getPassed(), is(1));
 		assertThat(report.getFailed(), is(0));
@@ -106,7 +109,7 @@ public class TestTestLinkSite {
 		verify(api)
 				.reportTCResult(3, 4, 2, status, 1,
 						"build-name", "notes", null, null, null, "platform",
-						null, null);
+						new HashMap<String, String>(), null);
 		Report report = testLinkSite.getReport();
 		assertThat(report.getPassed(), is(0));
 		assertThat(report.getFailed(), is(1));
@@ -126,7 +129,7 @@ public class TestTestLinkSite {
 		verify(api)
 				.reportTCResult(3, 4, 2, status, 1,
 						"build-name", "notes", null, null, null, "platform",
-						null, null);
+						new HashMap<String, String>(), null);
 		Report report = testLinkSite.getReport();
 		assertThat(report.getPassed(), is(0));
 		assertThat(report.getFailed(), is(0));


### PR DESCRIPTION
This PR adds a feature to read execution time custom field values from the ```JUnit.xml``` file and update the test results with them.
Example of ```JUnit.xml```:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite failures="0" tests="6" errors="1" time="0.149999856949">
    <testcase classname="FLASH_SET_test_01_start" name="FLASH_SET_test_01_start" time="0.0499999523163">
        <host_os>Windows</host_os>
        <error>
    </testcase>
    <testcase classname="FLASH_SET_test_01_start" name="FLASH_SET_test_01_start" time="0.0499999523163">
        <host_os>Windows</host_os>
    </testcase>
    <testcase classname="FLASH_SET_test_01_start" name="FLASH_SET_test_01_start" time="0.0499999523163">
        <host_os>Windows</host_os>
    </testcase>
</testsuite>
```