### PR TITLE
[JENKINS-49302] - Fix escaping of summary reports.

### DIFF
--- a/src/main/java/hudson/plugins/testlink/util/TestLinkHelper.java
+++ b/src/main/java/hudson/plugins/testlink/util/TestLinkHelper.java
@@ -338,8 +338,8 @@ public final class TestLinkHelper {
 	 */
 	public static String createReportSummary(Report testLinkReport, Report previous) {
 		StringBuilder builder = new StringBuilder();
-		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildID(testLinkReport.getBuildId())+"</b></p>");
-		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildName(testLinkReport.getBuildName())+"</b></p>");
+		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildID(escape(testLinkReport.getBuildId()))+"</b></p>");
+		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildName(Util.escape(testLinkReport.getBuildName()))+"</b></p>");
 		builder.append("<p><a href=\"" + TestLinkBuildAction.URL_NAME + "\">");
 		
 		Integer total = testLinkReport.getTestsTotal();
@@ -395,12 +395,12 @@ public final class TestLinkHelper {
         for(TestCaseWrapper tc: report.getTestCases() )
         {
         	builder.append("<tr>\n");
-        	
-        	builder.append("<td>"+tc.getId()+"</td>");
-        	builder.append("<td>"+tc.getFullExternalId()+"</td>");
-        	builder.append("<td>"+tc.getVersion()+"</td>");
-        	builder.append("<td>"+tc.getName()+"</td>");
-        	builder.append("<td>"+tc.getTestProjectId()+"</td>");
+
+        	builder.append("<td>"+escape(tc.getId())+"</td>");
+        	builder.append("<td>"+Util.escape(tc.getFullExternalId())+"</td>");
+        	builder.append("<td>"+escape(tc.getVersion())+"</td>");
+        	builder.append("<td>"+Util.escape(tc.getName())+"</td>");
+        	builder.append("<td>"+escape(tc.getTestProjectId())+"</td>");
     		builder.append("<td>"+TestLinkHelper.getExecutionStatusTextColored( tc.getExecutionStatus() )+"</td>\n");
         	
         	builder.append("</tr>\n");
@@ -408,6 +408,10 @@ public final class TestLinkHelper {
         
         builder.append("</table>");
         return builder.toString();
+	}
+
+	private static String escape(Integer integer) {
+		return integer != null ? Util.escape(integer.toString()) : "null" ;
 	}
 
 	

--- a/src/main/java/hudson/plugins/testlink/util/TestLinkHelper.java
+++ b/src/main/java/hudson/plugins/testlink/util/TestLinkHelper.java
@@ -338,7 +338,7 @@ public final class TestLinkHelper {
 	 */
 	public static String createReportSummary(Report testLinkReport, Report previous) {
 		StringBuilder builder = new StringBuilder();
-		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildID(escape(testLinkReport.getBuildId()))+"</b></p>");
+		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildID(testLinkReport.getBuildId())+"</b></p>");
 		builder.append("<p><b>"+Messages.ReportSummary_Summary_BuildName(Util.escape(testLinkReport.getBuildName()))+"</b></p>");
 		builder.append("<p><a href=\"" + TestLinkBuildAction.URL_NAME + "\">");
 		
@@ -396,11 +396,11 @@ public final class TestLinkHelper {
         {
         	builder.append("<tr>\n");
 
-        	builder.append("<td>"+escape(tc.getId())+"</td>");
+        	builder.append("<td>"+tc.getId()+"</td>");
         	builder.append("<td>"+Util.escape(tc.getFullExternalId())+"</td>");
-        	builder.append("<td>"+escape(tc.getVersion())+"</td>");
+        	builder.append("<td>"+tc.getVersion()+"</td>");
         	builder.append("<td>"+Util.escape(tc.getName())+"</td>");
-        	builder.append("<td>"+escape(tc.getTestProjectId())+"</td>");
+        	builder.append("<td>"+tc.getTestProjectId()+"</td>");
     		builder.append("<td>"+TestLinkHelper.getExecutionStatusTextColored( tc.getExecutionStatus() )+"</td>\n");
         	
         	builder.append("</tr>\n");
@@ -409,12 +409,6 @@ public final class TestLinkHelper {
         builder.append("</table>");
         return builder.toString();
 	}
-
-	private static String escape(Integer integer) {
-		return integer != null ? Util.escape(integer.toString()) : "null" ;
-	}
-
-	
 
 	/**
 	 * Prints the difference between two int values, showing a plus sign if the 

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuildAction/summary.jelly
@@ -6,7 +6,7 @@
 	xmlns:f="/lib/form"
     xmlns:i="jelly:fmt">
     <t:summary icon="/plugin/testlink/icons/testlink-48.png">
-		${it.summary}
-		${it.details}
+			<j:out value="${it.summary}"/>
+			<j:out value="${it.details}"/>
 	</t:summary>
 </j:jelly>


### PR DESCRIPTION
The utility methods are not used outside summary.jelly, so it should be fine.

@reviewbybees 