### PR TITLE
[JENKINS-50445] - Whitelist model objects from tap4j

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -19,3 +19,18 @@ com.tupilabs.testng.parser.Class
 com.tupilabs.testng.parser.Suite
 com.tupilabs.testng.parser.Test
 com.tupilabs.testng.parser.TestMethod
+
+# TAP parser
+# Whitelists safe classes from https://github.com/tupilabs/tap4j
+org.tap4j.model.BailOut
+org.tap4j.model.Comment
+org.tap4j.model.Directive
+org.tap4j.model.Footer
+org.tap4j.model.Header
+org.tap4j.model.Plan
+org.tap4j.model.SkipPlan
+org.tap4j.model.TapElement
+org.tap4j.model.TapResult
+org.tap4j.model.TestResult
+org.tap4j.model.TestSet
+org.tap4j.model.Text


### PR DESCRIPTION
This whitelist is a duplicate of https://github.com/jenkinsci/tap-plugin/blob/master/src/main/resources/META-INF/hudson.remoting.ClassFilter in TAP Plugin.
There is no TAP reporting test coverage in the plugin, and unfortunately I missed these classes during the review.

https://issues.jenkins-ci.org/browse/JENKINS-50445

@reviewbybees @jglick @kinow 
