### PR TITLE
Use credentials plugin for the developer API key, instead of storing in plain text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,11 @@
             <artifactId>junit</artifactId>
             <version>1.11</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.3.13</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,11 @@
             <artifactId>credentials</artifactId>
             <version>2.3.13</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.7</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/global.jelly
+++ b/src/main/resources/hudson/plugins/testlink/TestLinkBuilder/global.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   
   <f:section title="TestLink">
     <f:entry title="${%TestLink Installation}" 
@@ -18,9 +18,8 @@
               checkUrl="'${rootURL}/builder/TestLinkBuilder/checkMandatory?value='+escape(this.value)" />
           </f:entry>
 
-          <f:entry title="${%Developer Key}">
-            <f:textbox name="TestLink.devKey" value="${inst.devKey}" 
-              checkUrl="'${rootURL}/builder/TestLinkBuilder/checkMandatory?value='+escape(this.value)" />
+          <f:entry title="${%Credentials}" field="credentialsId">
+            <c:select/>
           </f:entry>
           
           <f:advanced>	  


### PR DESCRIPTION
Used [this PR](https://github.com/jenkinsci/sqlplus-script-runner-plugin/pull/26/files) as example. Probably related to https://www.jenkins.io/security/advisory/2019-08-07/#SECURITY-1428.

Happy if anyone takes over and tests/verifies that this works. Otherwise might have to wait until I have spare time to prepare the test environment & review it.

Bruno