### PR TITLE
Support testlink-java-api 1.9.20-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>br.eti.kinoshita</groupId>
             <artifactId>testlink-java-api</artifactId>
-            <version>1.9.17-0</version>
+            <version>1.9.20-1</version>
         </dependency>
         <dependency>
             <groupId>org.tap4j</groupId>
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -292,6 +292,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.24</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.0.8</version>
+            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/src/main/java/hudson/plugins/testlink/TestLinkSite.java
+++ b/src/main/java/hudson/plugins/testlink/TestLinkSite.java
@@ -211,16 +211,20 @@ public class TestLinkSite {
 				testPlan.getId(), 
 				testCase.getExecutionStatus(),
 				null, // List<TestCaseStepResult> steps
-				build.getId(), 
-				build.getName(), 
-				testCase.getNotes(), 
+				build.getId(),
+				build.getName(),
+				testCase.getNotes(),
+				null, // execution duration
 				null, // guess
 				null, // bug id
 				platformId, // platform id
 				platformName, // platform name
 				null, // custom fields
-				null);
-			
+				null, // overwrite
+				null, // user
+				null // timestamp
+				);
+
 			switch(testCase.getExecutionStatus()) {
     			case PASSED:
     				report.setPassed(report.getPassed()+1);


### PR DESCRIPTION
Upgraded TestLink instance to 1.9.20, afterwards the Jenkins project using the TestLink plug-in 3.16 failed with the known error:

```
12:30:22 FATAL: Error verifying developer key: Failed to parse server's response: Expected methodResponse element, got br
12:30:22 br.eti.kinoshita.testlinkjavaapi.util.TestLinkAPIException: Error verifying developer key: Failed to parse server's response: Expected methodResponse element, got br
```

As there is no plug-in version using testlink-java-api 1.9.20-1, this is the PR for it. Needed to adjust `reportTCResult` to fix the following error:

```
23:18:11 Looking for the test results of TestLink test cases.
23:18:11 
23:18:13 FATAL: 'br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse br.eti.kinoshita.testlinkjavaapi.TestLinkAPI.reportTCResult(java.lang.Integer, java.lang.Integer, java.lang.Integer, br.eti.kinoshita.testlinkjavaapi.constants.ExecutionStatus, java.util.List, java.lang.Integer, java.lang.String, java.lang.String, java.lang.Boolean, java.lang.String, java.lang.Integer, java.lang.String, java.util.Map, java.lang.Boolean)'
23:18:13 java.lang.NoSuchMethodError: 'br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse br.eti.kinoshita.testlinkjavaapi.TestLinkAPI.reportTCResult(java.lang.Integer, java.lang.Integer, java.lang.Integer, br.eti.kinoshita.testlinkjavaapi.constants.ExecutionStatus, java.util.List, java.lang.Integer, java.lang.String, java.lang.String, java.lang.Boolean, java.lang.String, java.lang.Integer, java.lang.String, java.util.Map, java.lang.Boolean)'
23:18:13     at hudson.plugins.testlink.TestLinkSite.updateTestCase(TestLinkSite.java:208)
23:18:13     at hudson.plugins.testlink.result.AbstractTAPFileNameResultSeeker.handleResult(AbstractTAPFileNameResultSeeker.java:182)
23:18:13     at hudson.plugins.testlink.result.AbstractTAPFileNameResultSeeker.updateTestCase(AbstractTAPFileNameResultSeeker.java:171)
23:18:13     at hudson.plugins.testlink.result.AbstractTAPFileNameResultSeeker.seek(AbstractTAPFileNameResultSeeker.java:149)
23:18:13     at hudson.plugins.testlink.result.TAPFileNameResultSeeker.seek(TAPFileNameResultSeeker.java:67)
23:18:13     at hudson.plugins.testlink.TestLinkBuilder.perform(TestLinkBuilder.java:197)
23:18:13     at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
23:18:13     at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:818)
23:18:13     at hudson.model.Build$BuildExecution.build(Build.java:199)
23:18:13     at hudson.model.Build$BuildExecution.doRun(Build.java:164)
23:18:13     at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:526)
23:18:13     at hudson.model.Run.execute(Run.java:1895)
23:18:13     at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
23:18:13     at hudson.model.ResourceController.execute(ResourceController.java:101)
23:18:13     at hudson.model.Executor.run(Executor.java:442)
```

### Testing done

The Jenkins project uses the basic build steps:

1. Invoke TestLink (here the initial error occurred due to the version incompatibility)
2. Test Execution
3. Iterative Test Build Steps
4. After iterating all test cases Build Steps
5. Result Seeking Strategy: TAP file name (here, the reportTCResult error occurred)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue